### PR TITLE
Manage User Accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
-  - tip
+  - 1.4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ $ script/build
 
 Now you can take the compiled `shortify` executable and put it where ever you want.
 
+**NOTE:** Currently, only go `1.4+` is supported. This should be easy to fix, so expect a new
+release shortly.
+
 ## Using Shortify
 
 Shortify is very simple. It has two endpoints:

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type CLICommand struct {
+	Pattern     string
+	Description string
+	Handler     func([]string)
+}
+
+var commands []CLICommand
+
+func init() {
+	commands = []CLICommand{
+		CLICommand{"users list", "users list --- lists all users", listUsers},
+		CLICommand{"users create .+", "users create [username] --- creates a new user", createUser},
+		CLICommand{".*", "help --- shows this menu", help},
+	}
+}
+
+func GetCLICommand(args []string) CLICommand {
+	helpCommand := commands[len(commands)-1]
+	cmdLine := strings.Join(args[1:], " ")
+
+	for _, cmd := range commands {
+		if match, _ := regexp.MatchString(cmd.Pattern, cmdLine); match {
+			return cmd
+		}
+	}
+
+	return helpCommand
+}
+
+func help(args []string) {
+	appName := args[0]
+
+	fmt.Printf("USAGE: %s [COMMAND] [OPTIONS]\n\n", appName)
+	fmt.Println("COMMANDS:")
+	fmt.Printf("%s --- runs the main application\n", appName)
+
+	for _, cmd := range commands {
+		fmt.Printf("%s %s\n", appName, cmd.Description)
+	}
+}
+
+func listUsers(args []string) {
+	users, err := GetUsers()
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		return
+	}
+
+	fmt.Println("USERS:")
+	for _, user := range users {
+		fmt.Println(user.Name)
+	}
+}
+
+func createUser(args []string) {
+	username := args[3]
+
+	if _, err := GetUser(username); err == nil {
+		fmt.Println("ERROR: User already exists!")
+		fmt.Println(err.Error())
+		return
+	}
+
+	user := NewUser(username)
+	if err := user.Save(); err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+	} else {
+		fmt.Printf("Created user: %s\n", user.Name)
+		fmt.Printf("Password: %s\n\n", user.Password)
+		fmt.Println("The password is not stored in plaintext and cannot be recovered. Be sure to copy it now.")
+	}
+}

--- a/cli.go
+++ b/cli.go
@@ -18,6 +18,7 @@ func init() {
 	commands = []CLICommand{
 		CLICommand{"users list", "users list --- lists all users", listUsers},
 		CLICommand{"users create .+", "users create [username] --- creates a new user", createUser},
+		CLICommand{"users resetpw .+", "users resetpw [username] --- generates a new password for [username]", resetPassword},
 		CLICommand{".*", "help --- shows this menu", help},
 	}
 }
@@ -74,7 +75,27 @@ func createUser(args []string) {
 		fmt.Printf("ERROR: %s\n", err.Error())
 	} else {
 		fmt.Printf("Created user: %s\n", user.Name)
-		fmt.Printf("Password: %s\n\n", user.Password)
-		fmt.Println("The password is not stored in plaintext and cannot be recovered. Be sure to copy it now.")
+		showPassword(*user)
 	}
+}
+
+func resetPassword(args []string) {
+	username := args[3]
+	user, err := GetUser(username)
+	if err != nil {
+		fmt.Printf("User %s not found", username)
+		return
+	}
+
+	if err = user.ResetPassword(); err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+	} else {
+		fmt.Printf("Reset password for user: %s\n", user.Name)
+		showPassword(user)
+	}
+}
+
+func showPassword(user User) {
+	fmt.Printf("Password: %s\n\n", user.Password)
+	fmt.Println("The password is not stored in plaintext and cannot be recovered. Be sure to copy it now.")
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"strings"
+	"testing"
+)
+
+type CLISuite struct {
+	suite.Suite
+}
+
+func TestCLISuite(t *testing.T) {
+	suite.Run(t, new(CLISuite))
+}
+
+func (suite *CLISuite) TestHelpCommand() {
+	t := suite.T()
+	command := GetCLICommand([]string{"shortify", "help"})
+	assert.True(t, strings.HasPrefix(command.Description, "help ---"))
+}
+
+func (suite *CLISuite) TestListUsersCommand() {
+	t := suite.T()
+	command := GetCLICommand([]string{"shortify", "users", "list"})
+	assert.True(t, strings.HasPrefix(command.Description, "users list ---"))
+}
+
+func (suite *CLISuite) TestCreateUserCommand() {
+	t := suite.T()
+	command := GetCLICommand([]string{"shortify", "users", "create", "pseudomuto"})
+	assert.True(t, strings.HasPrefix(command.Description, "users create [username] ---"))
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -32,3 +32,9 @@ func (suite *CLISuite) TestCreateUserCommand() {
 	command := GetCLICommand([]string{"shortify", "users", "create", "pseudomuto"})
 	assert.True(t, strings.HasPrefix(command.Description, "users create [username] ---"))
 }
+
+func (suite *CLISuite) TestResetUserPasswordCommand() {
+	t := suite.T()
+	command := GetCLICommand([]string{"shortify", "users", "resetpw", "pseudomuto"})
+	assert.True(t, strings.HasPrefix(command.Description, "users resetpw [username] ---"))
+}

--- a/database.go
+++ b/database.go
@@ -33,6 +33,7 @@ var currentDb = prodDb
 func mapForDatabase(db *sql.DB) *gorp.DbMap {
 	dbMap := &gorp.DbMap{Db: db, Dialect: currentDb.Dialect()}
 	dbMap.AddTableWithName(Redirect{}, "redirects").SetKeys(true, "Id")
+	dbMap.AddTableWithName(User{}, "users").SetKeys(true, "Id")
 	return dbMap
 }
 
@@ -89,6 +90,17 @@ func DbUpdate(entities ...interface{}) (int64, error) {
 	defer db.Close()
 	dbMap := mapForDatabase(db)
 	return dbMap.Update(entities...)
+}
+
+func DbSelectAll(holder interface{}, query string, args ...interface{}) ([]interface{}, error) {
+	db, err := openDb()
+	if err != nil {
+		return nil, err
+	}
+
+	defer db.Close()
+	dbMap := mapForDatabase(db)
+	return dbMap.Select(holder, query, args...)
 }
 
 func DbSelectOne(holder interface{}, query string, args ...interface{}) error {

--- a/handlers.go
+++ b/handlers.go
@@ -38,10 +38,21 @@ func RedirectShow(response http.ResponseWriter, request *http.Request) {
 	}
 }
 
+func isAuthorized(request *http.Request) bool {
+	username, password, ok := request.BasicAuth()
+	return ok && IsValidUser(username, password)
+}
+
 func RedirectCreate(response http.ResponseWriter, request *http.Request) {
 	response.Header().Set("Content-Type", jsonContentType)
-
 	encoder := json.NewEncoder(response)
+
+	if !isAuthorized(request) {
+		response.WriteHeader(http.StatusUnauthorized)
+		encoder.Encode(jsonErr{Code: http.StatusUnauthorized, Text: "Unauthorized"})
+		return
+	}
+
 	createParams, err := getCreateParams(request.Body)
 	if err != nil {
 		response.WriteHeader(HTTPUnprocessableEntity)

--- a/script/build
+++ b/script/build
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -x
+source script/bootstrap
 go build -o shortify

--- a/shortify.go
+++ b/shortify.go
@@ -1,19 +1,81 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 )
 
 const serverPort = ":8080"
 
 func main() {
-	routes := []Route{
-		Route{"PerformRedirect", "GET", "/{token}", RedirectShow},
-		Route{"CreateRedirect", "POST", "/redirects", RedirectCreate},
+	args := os.Args
+	InitializeDb()
+
+	if len(args) > 1 {
+		handleCommandLine(args)
+	} else {
+		routes := []Route{
+			Route{"PerformRedirect", "GET", "/{token}", RedirectShow},
+			Route{"CreateRedirect", "POST", "/redirects", RedirectCreate},
+		}
+
+		router := NewRouter(routes)
+		log.Fatal(http.ListenAndServe(serverPort, router))
+	}
+}
+
+func handleCommandLine(args []string) {
+	defer func() {
+		if r := recover(); r != nil {
+			help(args[0])
+		}
+	}()
+
+	switch string(args[1]) {
+	case "users":
+		if args[2] == "list" {
+			listUsers()
+		} else if args[2] == "create" {
+			createUser(args[3])
+		}
+	default:
+		help(args[0])
 	}
 
-	InitializeDb()
-	router := NewRouter(routes)
-	log.Fatal(http.ListenAndServe(serverPort, router))
+	fmt.Println()
+}
+
+func createUser(name string) {
+	user := NewUser(name)
+	if err := user.Save(); err != nil {
+		fmt.Printf("There was an error: %s\n", err.Error())
+	} else {
+		fmt.Printf("Created User: %s\n", name)
+		fmt.Println("Here's the password. This will never be shown again, so be sure to copy it")
+		fmt.Printf("Password: %s\n", user.Password)
+	}
+}
+
+func listUsers() {
+	users, err := GetUsers()
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		return
+	}
+
+	fmt.Println("USERS:")
+	for _, user := range users {
+		fmt.Println(user.Name)
+	}
+}
+
+func help(appName string) {
+	fmt.Printf("USAGE: %s [COMMAND] [OPTIONS]\n\n", appName)
+	fmt.Println("COMMANDS:")
+	fmt.Printf("%s --- runs the main application\n", appName)
+	fmt.Printf("%s users create [username] --- creates a new user\n", appName)
+	fmt.Printf("%s users list --- list existing users\n", appName)
+	fmt.Printf("%s help --- shows this menu\n", appName)
 }

--- a/shortify.go
+++ b/shortify.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -10,12 +9,9 @@ import (
 const serverPort = ":8080"
 
 func main() {
-	args := os.Args
 	InitializeDb()
 
-	if len(args) > 1 {
-		handleCommandLine(args)
-	} else {
+	if !processArgs() {
 		routes := []Route{
 			Route{"PerformRedirect", "GET", "/{token}", RedirectShow},
 			Route{"CreateRedirect", "POST", "/redirects", RedirectCreate},
@@ -26,56 +22,13 @@ func main() {
 	}
 }
 
-func handleCommandLine(args []string) {
-	defer func() {
-		if r := recover(); r != nil {
-			help(args[0])
-		}
-	}()
-
-	switch string(args[1]) {
-	case "users":
-		if args[2] == "list" {
-			listUsers()
-		} else if args[2] == "create" {
-			createUser(args[3])
-		}
-	default:
-		help(args[0])
+func processArgs() bool {
+	args := os.Args
+	if len(args) > 1 {
+		command := GetCLICommand(args)
+		command.Handler(args)
+		return true
 	}
 
-	fmt.Println()
-}
-
-func createUser(name string) {
-	user := NewUser(name)
-	if err := user.Save(); err != nil {
-		fmt.Printf("There was an error: %s\n", err.Error())
-	} else {
-		fmt.Printf("Created User: %s\n", name)
-		fmt.Println("Here's the password. This will never be shown again, so be sure to copy it")
-		fmt.Printf("Password: %s\n", user.Password)
-	}
-}
-
-func listUsers() {
-	users, err := GetUsers()
-	if err != nil {
-		fmt.Printf("ERROR: %s\n", err.Error())
-		return
-	}
-
-	fmt.Println("USERS:")
-	for _, user := range users {
-		fmt.Println(user.Name)
-	}
-}
-
-func help(appName string) {
-	fmt.Printf("USAGE: %s [COMMAND] [OPTIONS]\n\n", appName)
-	fmt.Println("COMMANDS:")
-	fmt.Printf("%s --- runs the main application\n", appName)
-	fmt.Printf("%s users create [username] --- creates a new user\n", appName)
-	fmt.Printf("%s users list --- list existing users\n", appName)
-	fmt.Printf("%s help --- shows this menu\n", appName)
+	return false
 }

--- a/user.go
+++ b/user.go
@@ -26,6 +26,12 @@ func NewUser(name string) *User {
 	return &user
 }
 
+func GetUser(name string) (User, error) {
+	var user User
+	err := DbSelectOne(&user, getSingleUserQuery, name)
+	return user, err
+}
+
 func GetUsers() ([]User, error) {
 	var users []User
 	_, err := DbSelectAll(&users, getUsersQuery)

--- a/user.go
+++ b/user.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"gopkg.in/gorp.v1"
+	"strings"
 	"time"
 )
 
@@ -21,7 +22,7 @@ type User struct {
 
 func NewUser(name string) *User {
 	user := User{Id: 0, Name: name}
-	user.Password = uuid.New()
+	user.Password = strings.Replace(uuid.New(), "-", "", -1)
 	return &user
 }
 

--- a/user.go
+++ b/user.go
@@ -22,7 +22,7 @@ type User struct {
 
 func NewUser(name string) *User {
 	user := User{Id: 0, Name: name}
-	user.Password = strings.Replace(uuid.New(), "-", "", -1)
+	user.Password = newPassword()
 	return &user
 }
 
@@ -55,6 +55,16 @@ func hashString(plaintext string) string {
 	hash := sha1.New()
 	hash.Write([]byte(plaintext))
 	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func newPassword() string {
+	return strings.Replace(uuid.New(), "-", "", -1)
+}
+
+func (self *User) ResetPassword() error {
+	self.Password = newPassword()
+	self.PasswordHash = hashString(self.Password)
+	return self.Save()
 }
 
 func (self *User) Save() error {

--- a/user.go
+++ b/user.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"code.google.com/p/go-uuid/uuid"
+	"crypto/sha1"
+	"fmt"
+	"gopkg.in/gorp.v1"
+	"time"
+)
+
+const getUsersQuery = "SELECT id, name, password_hash, created_at FROM users ORDER BY name"
+const getSingleUserQuery = "SELECT id, name, password_hash, created_at FROM users WHERE name = ?"
+
+type User struct {
+	Id           int64     `db:"id"`
+	Name         string    `db:"name"`
+	Password     string    `db:"-"`
+	PasswordHash string    `db:"password_hash"`
+	CreatedAt    time.Time `db:"created_at"`
+}
+
+func NewUser(name string) *User {
+	user := User{Id: 0, Name: name}
+	user.Password = uuid.New()
+	return &user
+}
+
+func GetUsers() ([]User, error) {
+	var users []User
+	_, err := DbSelectAll(&users, getUsersQuery)
+	return users, err
+}
+
+func IsValidUser(name string, password string) bool {
+	var user User
+	if err := DbSelectOne(&user, getSingleUserQuery, name); err != nil {
+		return false
+	}
+
+	return hashString(password) == user.PasswordHash
+}
+
+func (self *User) isNew() bool {
+	return self.Id == 0
+}
+
+func hashString(plaintext string) string {
+	hash := sha1.New()
+	hash.Write([]byte(plaintext))
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func (self *User) Save() error {
+	if self.isNew() {
+		return DbInsert(self)
+	}
+
+	_, err := DbUpdate(self)
+	return err
+}
+
+func (self *User) PreInsert(sqlExec gorp.SqlExecutor) error {
+	self.CreatedAt = time.Now()
+	self.PasswordHash = hashString(self.Password)
+	return nil
+}

--- a/user_test.go
+++ b/user_test.go
@@ -73,3 +73,17 @@ func (suite *UserSuite) TestIsValidUser() {
 	valid = IsValidUser("whoami", user.Password)
 	assert.False(t, valid)
 }
+
+func (suite *UserSuite) TestGetUser() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+	assert.Nil(t, err)
+
+	found, err := GetUser("testuser")
+	assert.Nil(t, err)
+	assert.Equal(t, user.Id, found.Id)
+
+	found, err = GetUser("whoisthis")
+	assert.NotNil(t, err)
+}

--- a/user_test.go
+++ b/user_test.go
@@ -87,3 +87,18 @@ func (suite *UserSuite) TestGetUser() {
 	found, err = GetUser("whoisthis")
 	assert.NotNil(t, err)
 }
+
+func (suite *UserSuite) TestResetPassword() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+	assert.Nil(t, err)
+
+	oldPassword := user.Password
+	oldPasswordHash := user.PasswordHash
+
+	err = user.ResetPassword()
+	assert.Nil(t, err)
+	assert.NotEqual(t, oldPassword, user.Password)
+	assert.NotEqual(t, oldPasswordHash, user.PasswordHash)
+}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+type UserSuite struct {
+	suite.Suite
+}
+
+func TestUserSuite(t *testing.T) {
+	suite.Run(t, new(UserSuite))
+}
+
+func (suite *UserSuite) SetupSuite() {
+	SetCurrentDb(true)
+	InitializeDb()
+}
+
+func (suite *UserSuite) TearDownSuite() {
+	SetCurrentDb(false)
+}
+
+func (suite *UserSuite) TearDownTest() {
+	TruncateDb()
+}
+
+func (suite *UserSuite) TestNewUser() {
+	t := suite.T()
+	user := NewUser("testuser")
+
+	assert.Equal(t, "testuser", user.Name)
+	assert.NotEmpty(t, user.Password)
+}
+
+func (suite *UserSuite) TestGetUsers() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+	assert.Nil(t, err)
+
+	users, err := GetUsers()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(users))
+}
+
+func (suite *UserSuite) TestUserSave() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+
+	assert.Nil(t, err)
+	assert.NotEqual(t, 0, user.Id)
+	assert.NotEmpty(t, user.PasswordHash)
+	assert.WithinDuration(t, time.Now(), user.CreatedAt, 100*time.Millisecond)
+}
+
+func (suite *UserSuite) TestIsValidUser() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+	assert.Nil(t, err)
+
+	valid := IsValidUser("testuser", user.Password)
+	assert.True(t, valid)
+
+	valid = IsValidUser("testuser", "someOtherPassword")
+	assert.False(t, valid)
+
+	valid = IsValidUser("whoami", user.Password)
+	assert.False(t, valid)
+}


### PR DESCRIPTION
Since the intention is for this to be hosted publicly, I figured it might be a good idea to put the redirect creation route behind some kind of authentication.

To keep things simple, I've used basic auth. However, to _help_ keep things secure, I've made it so that passwords are auto-generated `uuid`s and only the hashes are stored in the database. This makes it difficult to guess a p/w and ensures that a compromised DB doesn't rain on the shortify parade (without a collision attack at least).

For usage/hosting details, see the README file.
