### PR TITLE
Auto-Generate Unique Indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,6 @@ Currently, there is support for MySQL, PostgreSQL and Sqlite3. Very happy to rec
 
 For examples of how to configure each of these, check out the _examples/_ directory.
 
-#### A Quick Optimization
-
-You can speed up the application by adding _unique_ indexes for the following columns after creating
-the database.
-
-* `"redirects"."token"`
-* `"users"."name"`
-
-In a future version, this will happen automatically.
-
 ## Using Shortify
 
 Shortify is very simple. It has two endpoints:

--- a/shortify/database.go
+++ b/shortify/database.go
@@ -36,7 +36,8 @@ func newDatabase(provider string, dataSource string) database {
 
 func (self database) reset() error {
 	return withConnection(func(dbMap *gorp.DbMap) error {
-		return dbMap.TruncateTables()
+		dbMap.DropTables()
+		return dbMap.CreateTablesIfNotExists()
 	})
 }
 
@@ -76,8 +77,8 @@ func (self database) selectOne(holder interface{}, query string, args ...interfa
 
 func mapForDatabase(sqlDb *sql.DB) *gorp.DbMap {
 	dbMap := &gorp.DbMap{Db: sqlDb, Dialect: shortifyDb.connectionInfo.Dialect()}
-	dbMap.AddTableWithName(Redirect{}, "redirects").SetKeys(true, "Id")
-	dbMap.AddTableWithName(User{}, "users").SetKeys(true, "Id")
+	dbMap.AddTableWithName(Redirect{}, "redirects").SetKeys(true, "Id").ColMap("token").SetUnique(true)
+	dbMap.AddTableWithName(User{}, "users").SetKeys(true, "Id").ColMap("name").SetUnique(true)
 	return dbMap
 }
 

--- a/shortify/encode.go
+++ b/shortify/encode.go
@@ -1,12 +1,16 @@
 package shortify
 
-var shortifyEncoder encoder
+var shortifyEncoder encoderInterface
+
+type encoderInterface interface {
+	encode(value int64) string
+}
 
 type encoder struct {
 	charset string
 }
 
-func (self *encoder) encode(value int64) string {
+func (self encoder) encode(value int64) string {
 	if value == 0 {
 		return string(self.charset[0])
 	}

--- a/shortify/redirect_test.go
+++ b/shortify/redirect_test.go
@@ -10,6 +10,13 @@ type RedirectSuite struct {
 	suite.Suite
 }
 
+type TestEncoder struct {
+}
+
+func (self TestEncoder) encode(value int64) string {
+	return "token"
+}
+
 func TestRedirectSuite(t *testing.T) {
 	suite.Run(t, new(RedirectSuite))
 }
@@ -32,13 +39,29 @@ func (suite *RedirectSuite) TestNewRedirect() {
 
 func (suite *RedirectSuite) TestSaveNewRecord() {
 	t := suite.T()
-
 	redir := NewRedirect("http://www.google.com/")
 	err := redir.Save()
 
 	assert.Nil(t, err)
 	assert.NotEqual(t, 0, redir.Id)
 	assert.NotEmpty(t, redir.Token)
+}
+
+func (suite *RedirectSuite) TestTokenMustBeUnique() {
+	t := suite.T()
+
+	originalEncoder := shortifyEncoder
+	shortifyEncoder = TestEncoder{}
+
+	redir := NewRedirect("http://www.google.com/")
+	err := redir.Save()
+	assert.Nil(t, err)
+
+	redir = NewRedirect("http://www.google.com/")
+	err = redir.Save()
+	assert.NotNil(t, err)
+
+	shortifyEncoder = originalEncoder
 }
 
 func (suite *RedirectSuite) TestFindByTokenWhenFound() {

--- a/shortify/redirect_test.go
+++ b/shortify/redirect_test.go
@@ -47,7 +47,7 @@ func (suite *RedirectSuite) TestSaveNewRecord() {
 	assert.NotEmpty(t, redir.Token)
 }
 
-func (suite *RedirectSuite) TestTokenMustBeUnique() {
+func (suite *RedirectSuite) TestSaveErrorsWhenTokenIsntUnique() {
 	t := suite.T()
 
 	originalEncoder := shortifyEncoder

--- a/shortify/user_test.go
+++ b/shortify/user_test.go
@@ -53,6 +53,17 @@ func (suite *UserSuite) TestUserSave() {
 	assert.WithinDuration(t, time.Now(), user.CreatedAt, 100*time.Millisecond)
 }
 
+func (suite *UserSuite) TestUserNameMustBeUnique() {
+	t := suite.T()
+	user := NewUser("testuser")
+	err := user.Save()
+	assert.Nil(t, err)
+
+	user = NewUser("testuser")
+	err = user.Save()
+	assert.NotNil(t, err)
+}
+
 func (suite *UserSuite) TestIsValidUser() {
 	t := suite.T()
 	user := NewUser("testuser")


### PR DESCRIPTION
# The Problem

Currently (as outlined in the README) there is no unique indexes on `redirects.token` nor `user.name`. The README mentions that you should add these after creating the db (which happens automatically the first time the app is run).

It seems to me that this should happen automatically.
# The Solution

Adding the indexes by getting a hold of the `ColumnMap` during `mapForDatabase`. This is only used during creation, meaning there is no kind of validation. For this particular case, I'm ok with that.
