### PR TITLE
ensuring valid URLs during creation

### DIFF
--- a/shortify/handlers.go
+++ b/shortify/handlers.go
@@ -45,13 +45,12 @@ func createRedirectHandler(response http.ResponseWriter, request *http.Request) 
 			return
 		}
 
-		url, err := url.Parse(params.Url)
-		if err != nil || url.Scheme == "" {
+		if !isValidURL(params.Url) {
 			renderError(response, HTTPUnprocessableEntity, "Invalid url")
 			return
 		}
 
-		redir, err := FindOrCreateRedirect(url.String())
+		redir, err := FindOrCreateRedirect(params.Url)
 		if err != nil {
 			renderError(response, http.StatusInternalServerError, err.Error())
 		} else {
@@ -60,6 +59,11 @@ func createRedirectHandler(response http.ResponseWriter, request *http.Request) 
 			})
 		}
 	})
+}
+
+func isValidURL(inputUrl string) bool {
+	url, err := url.Parse(inputUrl)
+	return (err == nil && url.Scheme != "")
 }
 
 func renderError(response http.ResponseWriter, code int, message string) {

--- a/shortify/handlers.go
+++ b/shortify/handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 const TokenRouteParam = "token"
@@ -44,7 +45,13 @@ func createRedirectHandler(response http.ResponseWriter, request *http.Request) 
 			return
 		}
 
-		redir, err := FindOrCreateRedirect(params.Url)
+		url, err := url.Parse(params.Url)
+		if err != nil || url.Scheme == "" {
+			renderError(response, HTTPUnprocessableEntity, "Invalid url")
+			return
+		}
+
+		redir, err := FindOrCreateRedirect(url.String())
 		if err != nil {
 			renderError(response, http.StatusInternalServerError, err.Error())
 		} else {


### PR DESCRIPTION
@Karlhungus @nsimmons
# The Problem

As it stands, you can pass any string as the URL param and shortify will create a redirect for you. Obviously this sucks :8ball:s
# The Solution

Adding "validation" to the creation handler. Essentially, I've just attempted to parse the URL (via the `net/url` package) and error out (422) if an error occurs or if there is no scheme provided. 

This means that URLs must be absolute. However, no validation is done regarding which schemes are valid. Not sure if we should enforce a particular set of schemes or not. I mean, do we care if someone shortens a `tcp://` url? My initial thought is that we don't, so I didn't bother here.
