### PR TITLE
Weird Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shortify 
 
-[![Build Status](https://travis-ci.org/shortify/shortify.svg?branch=master)](https://travis-ci.org/shortify/shortify) [![GoDoc](https://godoc.org/github.com/shortify/shortify/shortify?status.svg)](https://godoc.org/github.com/shortify/shortify/shortify)
+[![Build Status](https://travis-ci.org/shortify/shortify.svg?branch=master)](https://travis-ci.org/shortify/shortify)
+[![GoDoc](https://godoc.org/github.com/shortify/shortify/app?status.svg)](https://godoc.org/github.com/shortify/shortify/app)
 
 A simple URL shortener application written in Go.
 

--- a/app/cli.go
+++ b/app/cli.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"fmt"

--- a/app/cli_test.go
+++ b/app/cli_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/config.go
+++ b/app/config.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"code.google.com/p/gcfg"

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/database.go
+++ b/app/database.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"database/sql"

--- a/app/database_test.go
+++ b/app/database_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/encode.go
+++ b/app/encode.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 var shortifyEncoder encoderInterface
 

--- a/app/encode_test.go
+++ b/app/encode_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"encoding/json"

--- a/app/handlers_test.go
+++ b/app/handlers_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"bytes"

--- a/app/model.go
+++ b/app/model.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import "time"
 

--- a/app/model_test.go
+++ b/app/model_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/redirect.go
+++ b/app/redirect.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"gopkg.in/gorp.v1"

--- a/app/redirect_test.go
+++ b/app/redirect_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/app/router.go
+++ b/app/router.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"fmt"

--- a/app/user.go
+++ b/app/user.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"code.google.com/p/go-uuid/uuid"

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -1,4 +1,4 @@
-package shortify
+package app
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/shortify.go
+++ b/shortify.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/shortify/shortify/shortify"
+	"github.com/shortify/shortify/app"
 	"log"
 	"net/http"
 	"os"
@@ -9,10 +9,10 @@ import (
 )
 
 func main() {
-	if shortify.Configure(configFilePath()) {
-		if !shortify.HandleCommandLine(os.Args) {
-			router := shortify.NewRouter()
-			log.Fatal(http.ListenAndServe(shortify.ServerPort(), router))
+	if app.Configure(configFilePath()) {
+		if !app.HandleCommandLine(os.Args) {
+			router := app.NewRouter()
+			log.Fatal(http.ListenAndServe(app.ServerPort(), router))
 		}
 	}
 }


### PR DESCRIPTION
@karlhungus
# The Problem

Not that this repo moved to the shortify org, the import package name became `github.com/shortify/shortify/shortify`.

That seems like too many shortifies to me.
# The Solution

Changing the internal package name to app. This makes the import package `github.com/shortify/shortify/app` which is one less shortify
